### PR TITLE
Fix "*.tiff" file loading

### DIFF
--- a/piscat/GUI/InputOutput/fun_reading.py
+++ b/piscat/GUI/InputOutput/fun_reading.py
@@ -31,11 +31,11 @@ class Reading(QtWidgets.QMainWindow):
             file_extention = os.path.splitext(self.filename)[1]
             if file_extention == ".pf" or file_extention == ".raw" or file_extention == ".bin" or file_extention == ".PF" or file_extention == ".RAW" or file_extention == ".BIN":
                 return "Raw"
-            elif file_extention == ".jpg" or file_extention == ".JPG" or file_extention == ".tiff" or file_extention == ".TIFF" or file_extention == ".png" or file_extention == ".PNG":
+            elif file_extention == ".jpg" or file_extention == ".JPG" or file_extention == ".png" or file_extention == ".PNG":
                 return "PNG"
             elif file_extention == ".avi" or file_extention == ".AVI":
                 return "AVI"
-            elif file_extention == ".TIF" or file_extention == ".tif":
+            elif file_extention == ".TIF" or file_extention == ".tif" or file_extention == ".tiff" or file_extention == ".TIFF":
                 return "TIF"
             elif file_extention == ".py" or file_extention == ".PY":
                 return "Python"


### PR DESCRIPTION
When opening multi-page TIFF files with the file extension "tiff" instead of "tif", PiSCAT was interpreting them as JPEG/PNG type files.